### PR TITLE
Add ingress for routing "/api/v1/namespaces"

### DIFF
--- a/deployments/server/templates/ingress.yaml
+++ b/deployments/server/templates/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "session-manager-server.fullname" . }}-http
+  labels:
+    {{- include "session-manager-server.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.ingressClassName }}
+  rules:
+  - http:
+      paths:
+      - path: /api/v1/namespaces
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "session-manager-server.fullname" . }}-http
+            port:
+              number: {{ .Values.httpPort }}


### PR DESCRIPTION
This will allow an ingress to route requests for session-manager.