### PR TITLE
Trim the base URL from the upgrade proxy

### DIFF
--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -75,7 +75,7 @@ func run(ctx context.Context, c *config.Config) error {
 
 	// External HTTPS server.
 	httpProxy := proxy.NewHTTPProxy(c.Server.BaseURL)
-	upgradeProxy := proxy.NewUpgradeProxy()
+	upgradeProxy := proxy.NewUpgradeProxy(c.Server.BaseURL)
 	httpProxy.SetObserver(upgradeProxy)
 	s := server.NewServer(server.Opts{
 		HTTPProxy:          httpProxy,

--- a/server/internal/proxy/upgrade.go
+++ b/server/internal/proxy/upgrade.go
@@ -29,13 +29,17 @@ type UpgradeProxy struct {
 
 	// numTakenTransports is the number of transports keyed by cluster ID.
 	numTakenTransports map[string]int
+
+	baseURL string
 }
 
 // NewUpgradeProxy returns a new ConnectProxy.
-func NewUpgradeProxy() *UpgradeProxy {
+func NewUpgradeProxy(baseURL string) *UpgradeProxy {
 	return &UpgradeProxy{
 		transports:         make(map[string][]*http.Transport),
 		numTakenTransports: make(map[string]int),
+
+		baseURL: baseURL,
 	}
 }
 
@@ -95,6 +99,8 @@ func (t *UpgradeProxy) Proxy(w http.ResponseWriter, r *http.Request) {
 	// the same TCP connection, which will result in an error when data is
 	// written to the connection.
 	r.URL.Host = hostPort
+
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, t.baseURL)
 
 	// NOTE: Request.RequestURI can't be set in client requests.
 	// http://golang.org/src/pkg/net/http/client.go

--- a/server/internal/proxy/upgrade_test.go
+++ b/server/internal/proxy/upgrade_test.go
@@ -20,7 +20,7 @@ func TestUpgradeProxy_AddRemove(t *testing.T) {
 	id := "foo"
 	conn := &net.TCPConn{}
 
-	p := NewUpgradeProxy()
+	p := NewUpgradeProxy("")
 
 	// Add a single connection to the pool.
 	err := p.Add(id, conn)
@@ -113,7 +113,7 @@ func TestUpgradeProxy_Proxy(t *testing.T) {
 	assert.NoError(t, err)
 
 	id := "test:80"
-	p := NewUpgradeProxy()
+	p := NewUpgradeProxy("")
 	err = p.Add(id, conn)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
The previous change was made to the regular HTTP request. We need to make the same change to the upgrade request.