### PR TITLE
Make a slight change to the agent helm value

### DIFF
--- a/deployments/agent/templates/configmap.yaml
+++ b/deployments/agent/templates/configmap.yaml
@@ -11,11 +11,11 @@ data:
       socket: /tmp/sockets/admin.sock
     proxy:
       http:
-        url: https://{{ .Values.proxy.address }}/_/agent/http
+        url: {{ .Values.proxy.baseUrl }}/_/agent/http
         poolSize: {{ $.Values.proxy.http.poolSize }}
         dialTimeout: 5s
       connect:
-        url: https://{{ .Values.proxy.address }}/_/agent/connect
+        url: {{ .Values.proxy.baseUrl }}/_/agent/connect
         poolSize: {{ $.Values.proxy.connect.poolSize }}
         dialTimeout: 5s
       tls:

--- a/deployments/agent/values.yaml
+++ b/deployments/agent/values.yaml
@@ -10,8 +10,7 @@ global:
 envoyClusterId: local-cluster-id
 
 proxy:
-  # Address of the proxy, in host:port format.
-  address: session-manager-server-worker-service-http:8082
+  baseUrl: http://session-manager-server-worker-service-http:8082
   http:
     # pool size of the HTTP tunnel
     poolSize: 3


### PR DESCRIPTION
We used to always have https:// in proxy URL, but it was misleading. While this doesn't impact the code (since we stop after establishing a transport), but it's better to set a proper URL.