### PR TITLE
Add dexServerAddr to the server config

### DIFF
--- a/common/pkg/auth/token_exchanger.go
+++ b/common/pkg/auth/token_exchanger.go
@@ -12,16 +12,21 @@ import (
 
 // TokenExchangerOptions is the options for TokenExchanger.
 type TokenExchangerOptions struct {
-	ClientID     string
-	ClientSecret string
-	BaseURL      string
-	IssuerURL    string
-	ResolverAddr string
+	ClientID      string
+	ClientSecret  string
+	BaseURL       string
+	IssuerURL     string
+	DexServerAddr string
+	ResolverAddr  string
 }
 
 // NewTokenExchanger returns a new TokenExchanger.
 func NewTokenExchanger(ctx context.Context, opts TokenExchangerOptions) (*TokenExchanger, error) {
-	provider, err := oidc.NewProvider(ctx, opts.IssuerURL)
+	// Allow the issuer URL to be different from the discovery URL (= URL that is passed to oidc.newProvider()).
+	// This is required since the discovery URL is the Dex server URL.
+	pCtx := oidc.InsecureIssuerURLContext(ctx, opts.IssuerURL)
+
+	provider, err := oidc.NewProvider(pCtx, fmt.Sprintf("http://%s/v1/dex", opts.DexServerAddr))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider: %v", err)
 	}

--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -21,6 +21,8 @@ data:
         {{- if .Values.global.auth.enable }}
         rbacServer:
           addr: {{ .Values.global.auth.rbacInternalServerAddr }}
+        dexServer:
+	  addr: {{ .Values.global.auth.dexServerAddr }}
         oidc:
           issuerUrl: {{ .Values.global.auth.oidcIssuerUrl }}
           clientId: {{ .Values.auth.oidcClientId }}

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -5,6 +5,7 @@ global:
     enable: true
     oidcIssuerUrl:
     rbacInternalServerAddr:
+    dexServerAddr:
 
   ingress:
     ingressClassName:
@@ -40,11 +41,16 @@ allowedOriginHosts:
 - localhost
 
 auth:
+  # These are the default values configured in https://github.com/llm-operator/rbac-manager/blob/main/deployments/dex-server/values.yaml#L43.
   oidcClientId: session-manager
   oidcClientSecret: o15FQlUB8SeOOBiw3Pg5vD5p
+  # This works when a local browser can hit the ingress controller
+  # Override the login URL and the redirect URL in JWKS. This is needed when the issuer URL is not reachable from
   resolverAddr: localhost:8080
   cacheExpiration: 1m
   cacheCleanup: 15m
+
+dexServerAddr: dex-server-http:5556
 
 debugLog: false
 
@@ -71,7 +77,7 @@ resources:
 podSecurityContext:
   fsGroup: 2000
 securityContext:
-  readOnlyRootFilesystem: true  
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
     - ALL

--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -43,11 +43,12 @@ func run(ctx context.Context, c *config.Config) error {
 	}
 
 	tex, err := auth.NewTokenExchanger(ctx, auth.TokenExchangerOptions{
-		ClientID:     c.Server.Auth.OIDC.ClientID,
-		ClientSecret: c.Server.Auth.OIDC.ClientSecret,
-		BaseURL:      c.BaseURL,
-		IssuerURL:    c.Server.Auth.OIDC.IssuerURL,
-		ResolverAddr: c.Server.Auth.OIDC.ResolverAddr,
+		ClientID:      c.Server.Auth.OIDC.ClientID,
+		ClientSecret:  c.Server.Auth.OIDC.ClientSecret,
+		BaseURL:       c.BaseURL,
+		IssuerURL:     c.Server.Auth.OIDC.IssuerURL,
+		DexServerAddr: c.Server.Auth.DexServer.Addr,
+		ResolverAddr:  c.Server.Auth.OIDC.ResolverAddr,
 	})
 	if err != nil {
 		return fmt.Errorf("new token exchanger: %w", err)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -88,6 +88,7 @@ func (a *Admin) validate() error {
 // Auth is the authentication configuration for the proxy.
 type Auth struct {
 	RBACServer      *RBACServerAuth `yaml:"rbacServer"`
+	DexServer       *DexServerAuth  `yaml:"dexServerAuth"`
 	OIDC            OIDC            `yaml:"oidc"`
 	CacheExpiration time.Duration   `yaml:"cacheExpiration"`
 	CacheCleanup    time.Duration   `yaml:"cacheCleanup"`
@@ -100,7 +101,11 @@ func (a *Auth) validate() error {
 	}
 
 	if err := a.RBACServer.validate(); err != nil {
-		return err
+		return fmt.Errorf("rbacServer: %s", err)
+	}
+
+	if err := a.DexServer.validate(); err != nil {
+		return fmt.Errorf("dexServer: %s", err)
 	}
 
 	if err := a.OIDC.validate(); err != nil {
@@ -122,6 +127,18 @@ type RBACServerAuth struct {
 }
 
 func (r *RBACServerAuth) validate() error {
+	if r.Addr == "" {
+		return fmt.Errorf("addr must be set")
+	}
+	return nil
+}
+
+// DexServerAuth is the configuration for authentication with Dex server.
+type DexServerAuth struct {
+	Addr string `yaml:"addr"`
+}
+
+func (r *DexServerAuth) validate() error {
 	if r.Addr == "" {
 		return fmt.Errorf("addr must be set")
 	}


### PR DESCRIPTION
Make the server use dexServerAddr to retrieve the OIDC configuration. This will allow the issuer URL to be a DNS name that is not resolvable/reachable from the inside k8s cluster (but is reachable from the local env).