### PR TITLE
Change how authentication is supported in a local Kind cluster

### DIFF
--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "session-manager-server.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    baseUrl: {{ .Values.global.llmOperatorBaseUrl }}
     admin:
       port: {{ .Values.adminPort }}
     server:
@@ -27,7 +26,7 @@ data:
           issuerUrl: {{ .Values.global.auth.oidcIssuerUrl }}
           clientId: {{ .Values.auth.oidcClientId }}
           clientSecret: {{ .Values.auth.oidcClientSecret }}
-          resolverAddr: {{ .Values.auth.resolverAddr }}
+          redirectUri:  {{ .Values.auth.oidcRedirectUri }}
         cacheExpiration: {{ .Values.auth.cacheExpiration }}
         cacheCleanup: {{ .Values.auth.cacheCleanup }}
         {{- end }}

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -1,6 +1,4 @@
 global:
-  llmOperatorBaseUrl:
-
   auth:
     enable: true
     oidcIssuerUrl:
@@ -44,9 +42,7 @@ auth:
   # These are the default values configured in https://github.com/llm-operator/rbac-manager/blob/main/deployments/dex-server/values.yaml#L43.
   oidcClientId: session-manager
   oidcClientSecret: o15FQlUB8SeOOBiw3Pg5vD5p
-  # This works when a local browser can hit the ingress controller
-  # Override the login URL and the redirect URL in JWKS. This is needed when the issuer URL is not reachable from
-  resolverAddr: localhost:8080
+  oidcRedirectUri: http://localhost:8080/v1/sessions/callback
   cacheExpiration: 1m
   cacheCleanup: 15m
 

--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -43,12 +43,12 @@ func run(ctx context.Context, c *config.Config) error {
 	}
 
 	tex, err := auth.NewTokenExchanger(ctx, auth.TokenExchangerOptions{
-		ClientID:      c.Server.Auth.OIDC.ClientID,
-		ClientSecret:  c.Server.Auth.OIDC.ClientSecret,
-		BaseURL:       c.BaseURL,
-		IssuerURL:     c.Server.Auth.OIDC.IssuerURL,
+		ClientID:     c.Server.Auth.OIDC.ClientID,
+		ClientSecret: c.Server.Auth.OIDC.ClientSecret,
+		IssuerURL:    c.Server.Auth.OIDC.IssuerURL,
+		RedirectURI:  c.Server.Auth.OIDC.RedirectURI,
+
 		DexServerAddr: c.Server.Auth.DexServer.Addr,
-		ResolverAddr:  c.Server.Auth.OIDC.ResolverAddr,
 	})
 	if err != nil {
 		return fmt.Errorf("new token exchanger: %w", err)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -11,16 +11,12 @@ import (
 
 // Config is the configuration for the proxy.
 type Config struct {
-	BaseURL string `yaml:"baseUrl"`
-	Server  Server `yaml:"server"`
-	Admin   Admin  `yaml:"admin"`
+	Server Server `yaml:"server"`
+	Admin  Admin  `yaml:"admin"`
 }
 
 // Validate validates the configuration.
 func (c *Config) Validate() error {
-	if c.BaseURL == "" {
-		return fmt.Errorf("baseUrl must be set")
-	}
 	if err := c.Server.validate(); err != nil {
 		return err
 	}
@@ -150,7 +146,7 @@ type OIDC struct {
 	ClientID     string `yaml:"clientId"`
 	ClientSecret string `yaml:"clientSecret"`
 	IssuerURL    string `yaml:"issuerUrl"`
-	ResolverAddr string `yaml:"resolverAddr"`
+	RedirectURI  string `yaml:"redirectUri"`
 }
 
 func (o *OIDC) validate() error {
@@ -163,8 +159,8 @@ func (o *OIDC) validate() error {
 	if o.IssuerURL == "" {
 		return fmt.Errorf("issuerUrl must be set")
 	}
-	if o.ResolverAddr == "" {
-		return fmt.Errorf("resolverAddr must be set")
+	if o.RedirectURI == "" {
+		return fmt.Errorf("redirectUri must be set")
 	}
 	return nil
 }


### PR DESCRIPTION
- Stop using BaseURL to construct a callback URL. Just directly specify it.

- Remove ResolverAddr. It was used to handle an issuer URL that is not reachable from outside of the cluster. For example, if the issuer URL is http://kong-proxy.kong/v1/dex, the calllback URL is updated to http://localhost:8080 with ResolverAddr, which is reachable from a local browser. Instead, we add a special logic that allows an issuer URL to be localhost. This simplifies the overall configuration in the local Kind cluster deployment.