### PR TITLE
feat: fall back to the Authorization heaer if a cookie is not available

### DIFF
--- a/server/internal/auth/authenticator_test.go
+++ b/server/internal/auth/authenticator_test.go
@@ -206,6 +206,27 @@ func TestExternalAuthenticatorTest(t *testing.T) {
 			wantClusterID: "my-cluster",
 			wantPath:      "/v1/sessions/my-cluster/v1/services/notebooks/nid",
 		},
+		{
+			name: "ingress path with authorization token",
+			req: &http.Request{
+				URL: &url.URL{
+					Path: "/v1/sessions/my-cluster/v1/services/notebooks/nid",
+				},
+				Header: http.Header{
+					"Authorization": []string{"token"},
+				},
+			},
+			userInfo: auth.UserInfo{
+				AssignedKubernetesEnvs: []auth.AssignedKubernetesEnv{
+					{
+						ClusterID: "my-cluster",
+						Namespace: "my-namespace",
+					},
+				},
+			},
+			wantClusterID: "my-cluster",
+			wantPath:      "/v1/sessions/my-cluster/v1/services/notebooks/nid",
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
This is for the case where the request is forwarded to an HTTP server (e.g., vLLM) running inside a Jupyter Notebook. Such a request can be made from a non-browser client, so we need to support it.